### PR TITLE
Refresh site content with latest resume

### DIFF
--- a/assets/resume.pdf
+++ b/assets/resume.pdf
@@ -1,0 +1,36 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 67 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+(Resume placeholder) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000114 00000 n 
+0000000248 00000 n 
+0000000350 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+396
+%%EOF

--- a/index.html
+++ b/index.html
@@ -5,17 +5,14 @@
     <title>🌐 Rishabh Pandey</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-    <meta name="description" content="Welcome to the personal website of Rishabh Pandey, a senior studying Computer Science at Purdue University with a concentration in Machine Intelligence. Explore my portfolio, work experience, projects, and skills. Connect with me to learn how I can contribute to your organization's tech initiatives."
-    />
+    <meta name="description" content="Welcome to the personal website of Rishabh Pandey, a software engineer and Purdue University Computer Science graduate. Explore my portfolio, work experience, projects, and skills. Connect with me to learn how I can contribute to your organization's tech initiatives." />
     <meta name="keywords" content="Rishabh Pandey Purdue CS Software Engineering Geico Texas Instruments Akpsi" />
     <link rel="stylesheet" href="assets/css/main.css" />
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/devicon.min.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=6">
-
 </head>
 
 <body class="is-preload">
-
     <nav id="navbar">
         <div class="nav-links">
             <a href="#about-me">About</a>
@@ -23,6 +20,7 @@
             <a href="#professional">Work Exp.</a>
             <a href="#projects">Projects</a>
             <a href="#skills">Skills</a>
+            <a href="assets/resume.pdf" target="_blank" rel="noopener noreferrer">Resume</a>
         </div>
     </nav>
 
@@ -31,7 +29,7 @@
         <section class="intro">
             <header>
                 <h1>👋 Hi! I'm Rishabh</h1>
-                <p>Senior @ Purdue CS 👨‍💻</p>
+                <p>Software Engineer @ GEICO</p>
                 <ul class="icons">
                     <li><a href="https://www.linkedin.com/in/pandey-rishabh/" class="icon brands fa-linkedin-in" target="_blank" rel="noopener noreferrer" aria-label="goto linkedin"><span class="label">LinkedIn</span></a></li>
                     <li><a href="https://github.com/rishabhxpandey/" class="icon brands fa-github" target="_blank" rel="noopener noreferrer" aria-label="goto github"><span class="label">GitHub</span></a></li>
@@ -39,7 +37,6 @@
                     <li><a href="https://www.instagram.com/rishabhxpandey/" target="_blank" rel="noopener noreferrer" class="icon brands fa-instagram" aria-label="goto instagram"><span class="label">Instagram</span></a></li>
                     <li><a href="https://open.spotify.com/user/pandeyrishabh0403" class="icon brands fa-spotify" target="_blank" rel="noopener noreferrer" aria-label="goto spotify"><span class="label">Spotify</span></a></li>
                     <li><a href="mailto:email.rishabhp@gmail.com" class="icon brands fa-google" target="_blank" rel="noopener noreferrer" aria-label="goto email"><span class="label">Gmail</span></a></li>
-
                 </ul>
                 <ul class="actions">
                     <li><a href="#about-me" class="arrow scrolly" aria-label="scroll downnn"><span class="label">Next</span></a></li>
@@ -56,10 +53,7 @@
                 <h2>About Me!</h2>
             </header>
             <div class="content">
-                <p>My passion lies in using computer science to solve real-world problems across a range of industries, including technology, finance, e-commerce, healthcare, and insurance. With a strong foundation in data analytics, machine learning, and
-                    software engineering, I am eager to apply my skills in internships that allow me to make a meaningful impact.
-                    <br>
-                    <br> This summer, I will be joining the Data Tech Team @ Geico as a Software Engineering Intern. Let's connect to learn more about my background and how I can support your organization's initiatives!</p>
+                <p>Software engineer with a passion for building cloud-native services and AI-driven applications. I’m pursuing a B.S. in Computer Science at Purdue University (Dec 2024) and currently work at GEICO, where I build scalable contact center technology on AWS. I enjoy tackling real-world problems across industries and collaborating on impactful projects.</p>
             </div>
         </section>
 
@@ -69,30 +63,31 @@
                 <h2>Education</h2>
             </header>
             <div class="content">
-
                 <div class="content">
                     <div class="experience-grid">
-
                         <div class="education-section">
                             <div class="education-content">
                                 <div class="degree-info">
                                     <img src="images/purdue.webp" alt="Purdue University Logo" class="purdue-logo">
                                     <div class="degree-details">
                                         <h3>PURDUE UNIVERSITY</h3>
-                                        <p>Bachelor of Science in Computer Science<br> Concentration: Machine Intelligence<br> GPA: 3.47 / 4.00<br> Expected Graduation: December 2024</p>
+                                        <p>B.S. in Computer Science<br>Expected Graduation: December 2024</p>
                                     </div>
                                 </div>
                                 <h3>Relevant Coursework</h3>
                                 <ul class="coursework">
-                                    <li>Systems Programming</li>
-                                    <li>Software Engineering</li>
-                                    <li>Information Systems</li>
-                                    <li>Cloud Computing</li>
                                     <li>Operating Systems</li>
-                                    <li>Data Mining & ML</li>
-                                    <li>Analysis of Algorithms</li>
-                                    <li><i>Introduction to RDBMS</i></li>
-                                    <li>Artificial Intelligence</li>
+                                    <li>Computer Networks</li>
+                                    <li>Database Systems</li>
+                                    <li>Cloud Computing</li>
+                                    <li>AI/ML</li>
+                                </ul>
+                                <h3>Activities &amp; Societies</h3>
+                                <ul class="coursework">
+                                    <li>Alpha Kappa Psi</li>
+                                    <li>ML@Purdue</li>
+                                    <li>PurdueTHINK</li>
+                                    <li>Intramural Soccer</li>
                                 </ul>
                             </div>
                         </div>
@@ -109,39 +104,38 @@
             <div class="content">
                 <div class="content">
                     <div class="experience-grid">
-
                         <div class="experience-box">
                             <img src="images/geico.webp" alt="Geico Logo" class="experience-logo">
-                            <h3>Software Engineering Intern</h3>
+                            <h3>Software Engineer</h3>
                             <h3>@ GEICO</h3>
-                            <p><strong>Summer 2024</strong></p>
-                            <p>On the Data Tech Team.</p>
+                            <p><strong>Jan 2025 – Present</strong></p>
+                            <ul>
+                                <li>Built Python AWS Lambda services to normalize contact events, batch-write to DynamoDB, and fan-out via EventBridge with DLQs/backoff—processing ~350–500 events/min avg.</li>
+                                <li>Shipped Amazon Connect queue observability scanning ~800–900 queues, cutting runtime ~120s → ~10s and adding a DynamoDB "ignore list" to suppress noise.</li>
+                                <li>Refactored Terraform modules with least-privilege IAM and standardized alarms, DLQs, and structured logging.</li>
+                                <li>Achieved ~90% PyTest coverage and standardized JSON logging and runbooks.</li>
+                                <li>Participated in AI Hackathon: developed a RAG agent mapping natural-language intents to policy updates for a customer.</li>
+                            </ul>
                         </div>
-
                         <div class="experience-box">
-                            <img src="images/AGRO.svg" alt="Agrofocal Logo" class="experience-logo">
-                            <h3>AI/Software Intern </h3>
-                            <h3>@ Agrofocal Technologies</h3>
-                            <p><strong>Fall 2023 (Remote)</strong></p>
-                            <p>Optimized predictive analysis and enhanced accuracy of crop yield forecasts using machine learning and custom image processing scripts.</p>
+                            <img src="images/geico.webp" alt="Geico Logo" class="experience-logo">
+                            <h3>Software Development Intern</h3>
+                            <h3>@ GEICO</h3>
+                            <p><strong>Jun 2024 – Aug 2024</strong></p>
+                            <ul>
+                                <li>Deployed JupyterHub on AKS with Azure AD SSO/RBAC and Spark + ADLS, onboarding 20+ users and contributing to ~25% Snowflake cost reduction (~$3M/yr).</li>
+                                <li>Published custom Jupyter magics for one-click data access and enforced quotas/autoscaling to stabilize peak loads.</li>
+                            </ul>
                         </div>
-
                         <div class="experience-box">
-                            <img src="images/TI.webp" alt="TI Logo" class="experience-logo">
+                            <img src="images/TI.webp" alt="Texas Instruments Logo" class="experience-logo">
                             <h3>Software Engineering Intern</h3>
                             <h3>@ Texas Instruments</h3>
-                            <p><strong>Summer 2023</strong></p>
-                            <p>Developed Internal Tools for the Customer Support Team under the EdTech Organization.</p>
+                            <p><strong>May 2023 – Aug 2023</strong></p>
+                            <ul>
+                                <li>Shipped Oracle APEX+PL/SQL app integrating 10Duke REST API; reduced license lookup from 4–6 hrs to ~3–5 sec across 250+ products and added audit logs and archival automation.</li>
+                            </ul>
                         </div>
-
-                        <div class="experience-box">
-                            <img src="images/purdue2.webp" alt="Purdue Logo" class="experience-logo">
-                            <h3>Teaching Assistant</h3>
-                            <h3>@ Purdue University</h3>
-                            <p><strong>Spring 2023 — Present</strong></p>
-                            <p>Collaborating with graduate TAs to plan and execute lab activities that reinforce course material, encourage student engagement, and improve their problem-solving abilities.</p>
-                        </div>
-
                     </div>
                 </div>
             </div>
@@ -155,56 +149,23 @@
             <div class="content">
                 <div class="content">
                     <div class="experience-grid">
-
                         <div class="experience-box">
-                            <h3> OOTD: Outfit of the Day</h3>
-                            <p>A virtual closet iOS application designed to help users organize their wardrobe, plan outfits, and share their style with friends!</p>
-                            <a href="https://github.com/OOTD-Virtual-Closet/OOTD-Swift" class="link-icon" target="_blank" aria-label="repo link">
+                            <h3> LinkedIn Interview Agent</h3>
+                            <p>Agentic interview platform: Job description and resume ingestion, semantic skill mapping (FAISS), adaptive question generation, and structured logging for latency and cost metrics.</p>
+                            <a href="https://github.com/rishabhxpandey/lnkd_apb" class="link-icon" target="_blank" aria-label="repo link">
                                 <i class="icon brands fa-github"></i>
                             </a>
                             <ul class="tech-stack">
-                                <li class="tech-stack-item">Swift</li>
-                                <li class="tech-stack-item">SwiftUI</li>
-                                <li class="tech-stack-item">Firebase</li>
+                                <li class="tech-stack-item">FastAPI</li>
+                                <li class="tech-stack-item">React</li>
+                                <li class="tech-stack-item">GPT-4o</li>
+                                <li class="tech-stack-item">FAISS</li>
                             </ul>
                         </div>
-
-                        <div class="experience-box">
-                            <h3> Xinu OS</h3>
-                            <p>Implemented key features in the Xinu OS, including process coordination, synchronization with semaphores, enhancements to the file system for efficient storage management, and deadlock detection, improving system reliability
-                                and performance.</p>
-                            <ul class="tech-stack">
-                                <li class="tech-stack-item">C</li>
-                                <li class="tech-stack-item">x86 Assembly</li>
-                                <li class="tech-stack-item">Multithreading</li>
-                            </ul>
-                        </div>
-
-                        <div class="experience-box">
-                            <h3> Daily News Pipeline</h3>
-                            <p>Created an automated Python application hosted on AWS EC2 that gathers daily news from multiple sources, categorizes them, and facilitates distribution via text messages to curated news feeds.</p>
-                            <ul class="tech-stack">
-                                <li class="tech-stack-item">Python</li>
-                                <li class="tech-stack-item">TwilioAPI</li>
-                                <li class="tech-stack-item">AWS</li>
-                            </ul>
-                        </div>
-
-                        <div class="experience-box">
-                            <h3> Custom Shell Interpreter</h3>
-                            <p>Engineered an advanced shell interpreter in C, enhancing user interaction through features like signal handling, environment variable expansion, and an integrated line editor for an optimized command-line experience.</p>
-                            <ul class="tech-stack">
-                                <li class="tech-stack-item">C/C++</li>
-                                <li class="tech-stack-item">Flex/Bison</li>
-                                <li class="tech-stack-item">Git</li>
-                            </ul>
-                        </div>
-
                     </div>
                 </div>
             </div>
         </section>
-
 
         <!-- Section -->
         <section id="skills">
@@ -213,56 +174,60 @@
             </header>
             <div class="content">
                 <div class="skills-grid">
-
                     <div class="skill-icon">
                         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/python/python-original.svg" alt="python" />
                     </div>
-
                     <div class="skill-icon">
-                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/java/java-original-wordmark.svg" alt="java" />
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/java/java-original.svg" alt="java" />
                     </div>
-
                     <div class="skill-icon">
                         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/c/c-original.svg" alt="c" />
                     </div>
-
                     <div class="skill-icon">
-                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/javascript/javascript-original.svg" alt="javascript" />
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/go/go-original.svg" alt="go" />
                     </div>
-
                     <div class="skill-icon">
-                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/swift/swift-original.svg" alt="swift" />
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg" alt="typescript" />
                     </div>
-
-                    <div class="skill-icon">
-                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/go/go-original-wordmark.svg" alt="golang" />
-                    </div>
-
                     <div class="skill-icon">
                         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/amazonwebservices/amazonwebservices-original-wordmark.svg" alt="aws" />
                     </div>
-
                     <div class="skill-icon">
-                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/docker/docker-original-wordmark.svg" alt="docker" />
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/azure/azure-original.svg" alt="azure" />
                     </div>
-
                     <div class="skill-icon">
-                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/postman/postman-original.svg" alt="postman" />
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/googlecloud/googlecloud-original.svg" alt="gcp" />
                     </div>
-
                     <div class="skill-icon">
-                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/sqldeveloper/sqldeveloper-original.svg" alt="sqldeveloper" />
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/docker/docker-original.svg" alt="docker" />
                     </div>
-
+                    <div class="skill-icon">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/kubernetes/kubernetes-plain.svg" alt="kubernetes" />
+                    </div>
+                    <div class="skill-icon">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/terraform/terraform-original.svg" alt="terraform" />
+                    </div>
+                    <div class="skill-icon">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/git/git-original.svg" alt="git" />
+                    </div>
+                    <div class="skill-icon">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/github/github-original.svg" alt="github" />
+                    </div>
                     <div class="skill-icon">
                         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/linux/linux-original.svg" alt="linux" />
                     </div>
-
                     <div class="skill-icon">
-                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/oracle/oracle-original.svg" alt="oracle" />
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/postgresql/postgresql-original.svg" alt="postgresql" />
                     </div>
-
-
+                    <div class="skill-icon">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/redis/redis-original.svg" alt="redis" />
+                    </div>
+                    <div class="skill-icon">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/fastapi/fastapi-original.svg" alt="fastapi" />
+                    </div>
+                    <div class="skill-icon">
+                        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/scikitlearn/scikitlearn-original.svg" alt="scikit-learn" />
+                    </div>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- update homepage hero and nav to include resume link and current role
- sync About, Education, Experience, Projects, and Skills sections with latest resume details
- add downloadable resume placeholder

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ad4497040832fb8348fd85f0f5378